### PR TITLE
文字列分割にスプレッド構文を使用

### DIFF
--- a/TinySegmenter.js
+++ b/TinySegmenter.js
@@ -81,7 +81,7 @@ const segment = (input) => {
   const result = [];
   const seg = ["B3","B2","B1"];
   const ctype = ["O","O","O"];
-  const o = input.split("");
+  const o = [...input];
   for (const i of o) {
     seg.push(i);
     ctype.push(ctype_(i))


### PR DESCRIPTION
`input.split("")`はサロゲートペアを含んだ文字列の際に結果がおかしくなる可能性があるため、`[...input]`を使用する形に修正しました

```ts
console.log(TinySegmenter.segment("楽しいパーティ🥳"));

// before
// [ "楽しい", "パーティ", "�", "�" ]

// after
// [ "楽しい", "パーティ", "🥳" ]
```